### PR TITLE
Add macOS notification alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A powerful and intelligent command-line utility for finding and cleaning unneces
 - ⚡ **Fast Scanning**: Efficient directory traversal with configurable depth limits
 - 🎨 **Clean Output**: Well-formatted terminal output with progress indicators
 - 📊 **Progress Tracking**: Real-time progress bars with ETA for long operations
+- 🛎️ **System Notifications**: macOS alerts when scans or cleanups finish
 
 ## Categories Detected
 


### PR DESCRIPTION
## Summary
- add `send_notification` helper that uses `osascript` on macOS
- notify after scans and cleanups about potential and actual freed space
- describe new notification feature in the README

## Testing
- `python3 -m py_compile macsweep.py`
- `python3 macsweep.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_687301afb41083339ac0d7dd10dbbf7c