### PR TITLE
Add log file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A powerful and intelligent command-line utility for finding and cleaning unneces
 - ⚡ **Fast Scanning**: Efficient directory traversal with configurable depth limits
 - 🎨 **Clean Output**: Well-formatted terminal output with progress indicators
 - 📊 **Progress Tracking**: Real-time progress bars with ETA for long operations
+- 📝 **Log File**: Detailed logs of cleanup activity saved to `~/.macsweep.log`
 
 ## Categories Detected
 
@@ -83,6 +84,7 @@ Options:
   --clean-downloads     Interactive Downloads cleanup with format selection
   --organize-downloads  Organize Downloads files into separate folders by category
   --no-progress         Disable progress bars for minimal output
+  --log-file PATH       Write log output to the specified file (default: ~/.macsweep.log)
   --help                Show help message
 ```
 
@@ -190,7 +192,7 @@ When you run the script, you'll see:
 - **Confirmation Prompts**: Always asks before deleting files
 - **Safe Categorization**: Only suggests files that are typically safe to delete
 - **Error Handling**: Gracefully handles permission errors and missing files
-- **Detailed Logging**: Shows exactly what was deleted (in verbose mode)
+- **Detailed Logging**: Logs all cleanup actions to a file for troubleshooting
 
 ## System Requirements
 


### PR DESCRIPTION
## Summary
- configure logging and write to a file
- log cleanup actions in `CleanupEngine`
- expose `--log-file` CLI option
- document logging in README

## Testing
- `python3 macsweep.py --help | head`
- `python3 -m py_compile macsweep.py`

------
https://chatgpt.com/codex/tasks/task_b_687301b977188333b82ac71a2b4a5210